### PR TITLE
Experiment with subprocess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 lint: flake8 black-check isort-check mypy
 
+fmt: black isort
+
 flake8:
 	flake8 .
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author="Rupert Bedford",
     author_email="rupert@rupertb.com",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["python-language-server", "black", "toml"],
+    install_requires=["python-language-server", "black"],
     extras_require={"dev": ["isort", "flake8", "pytest", "mypy", "pytest"]},
     entry_points={"pyls": ["pyls_black = pyls_black.plugin"]},
     classifiers=(

--- a/tests/fixtures/config/pyproject.toml
+++ b/tests/fixtures/config/pyproject.toml
@@ -1,6 +1,2 @@
 [tool.black]
 line-length = 20
---fast = true
-py36 = true
-pyi = true
-skip-string-normalization = true

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from pyls.workspace import Document
 
-from pyls_black.plugin import load_config, pyls_format_document, pyls_format_range
+from pyls_black.plugin import pyls_format_document, pyls_format_range
 
 here = Path(__file__).parent
 fixtures_dir = here / "fixtures"
@@ -122,27 +122,3 @@ def test_pyls_format_range_syntax_error(invalid_document):
     result = pyls_format_range(invalid_document, range=range)
 
     assert result == []
-
-
-def test_load_config():
-    config = load_config(fixtures_dir / "config" / "example.py")
-
-    assert config == {
-        "line_length": 20,
-        "py36": True,
-        "pyi": True,
-        "fast": True,
-        "skip_string_normalization": True,
-    }
-
-
-def test_load_config_defaults():
-    config = load_config(fixtures_dir / "example.py")
-
-    assert config == {
-        "line_length": 88,
-        "py36": False,
-        "pyi": False,
-        "fast": False,
-        "skip_string_normalization": False,
-    }


### PR DESCRIPTION
Experiment with running `python -m black` via `subprocess` rather than importing the `black` Python module.

Pros:

* No longer need to parse the `black` TOML config.
* Won't break if the `black` functions we're using get refactored (not sure how stable that API is).

Cons:

* A lot slower due to Python startup time.