### PR TITLE
Prefer black over other formatter plugins

### DIFF
--- a/pyls_black/plugin.py
+++ b/pyls_black/plugin.py
@@ -5,12 +5,12 @@ import toml
 from pyls import hookimpl
 
 
-@hookimpl
+@hookimpl(tryfirst=True)
 def pyls_format_document(document):
     return format_document(document)
 
 
-@hookimpl
+@hookimpl(tryfirst=True)
 def pyls_format_range(document, range):
     range["start"]["character"] = 0
     range["end"]["line"] += 1


### PR DESCRIPTION
This adds the tryfirst=True hookimpl argument, similarly to the [builtin autopep8 plugin](https://github.com/palantir/python-language-server/blob/d294fe14b632ca14f333552b572650dda8327a2a/pyls/plugins/autopep8_format.py#L9) to (try to) ensure black is attempted before other formatters.