### PR TITLE
Set target_version to set() on the default config

### DIFF
--- a/pyls_black/plugin.py
+++ b/pyls_black/plugin.py
@@ -66,6 +66,7 @@ def load_config(filename: str) -> Dict:
         "fast": False,
         "pyi": filename.endswith(".pyi"),
         "skip_string_normalization": False,
+        "target_version": set(),
     }
 
     root = black.find_project_root((filename,))


### PR DESCRIPTION
This happens whenever running pyls_black on a project that doesn't
define a config file (there's an early return).

Writing a test for this can get tricky, but I could give it a shot.

Follow up from #20.