### PR TITLE
Change python-language-server to python-lsp-server

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyls-black
-version = 0.4.6
+version = 1.0.0
 author = Rupert Bedford
 author_email = rupert@rupertb.com
 description = Black plugin for the Python Language Server
@@ -14,7 +14,7 @@ classifiers =
 
 [options]
 packages = find:
-install_requires = python-language-server; black>=19.3b0; toml
+install_requires = python-lsp-server; black>=19.3b0; toml
 python_requires = >= 3.6
 
 [options.entry_points]


### PR DESCRIPTION
`python-lsp-server` is an active fork of now unmaintained `python-language-server`