### PR TITLE
Fix test failure with black 21.4b0+

### DIFF
--- a/pyls_black/plugin.py
+++ b/pyls_black/plugin.py
@@ -4,6 +4,8 @@ import black
 import toml
 from pyls import hookimpl
 
+_PY36_VERSIONS = {black.TargetVersion[v] for v in ["PY36", "PY37", "PY38", "PY39"]}
+
 
 @hookimpl(tryfirst=True)
 def pyls_format_document(document):
@@ -97,7 +99,7 @@ def load_config(filename: str) -> Dict:
             black.TargetVersion[x.upper()] for x in file_config["target_version"]
         )
     elif file_config.get("py36"):
-        target_version = black.PY36_VERSIONS
+        target_version = _PY36_VERSIONS
     else:
         target_version = set()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,7 +8,12 @@ import pytest
 from pyls import uris
 from pyls.workspace import Document, Workspace
 
-from pyls_black.plugin import load_config, pyls_format_document, pyls_format_range
+from pyls_black.plugin import (
+    _PY36_VERSIONS,
+    load_config,
+    pyls_format_document,
+    pyls_format_range,
+)
 
 here = Path(__file__).parent
 fixtures_dir = here / "fixtures"
@@ -191,7 +196,7 @@ def test_load_config_target_version():
 def test_load_config_py36():
     config = load_config(str(fixtures_dir / "py36" / "example.py"))
 
-    assert config["target_version"] == black.PY36_VERSIONS
+    assert config["target_version"] == _PY36_VERSIONS
 
 
 def test_load_config_defaults():


### PR DESCRIPTION
Inline PY36_VERSIONS because black no longer exposes it (more details in #36).

Closes #36.