### PR TITLE
Add support for black 22.1.0

### DIFF
--- a/pyls_black/plugin.py
+++ b/pyls_black/plugin.py
@@ -73,7 +73,13 @@ def load_config(filename: str) -> Dict:
 
     root = black.find_project_root((filename,))
 
-    pyproject_filename = root / "pyproject.toml"
+    # Note: find_project_root returns a tuple in 22.1.0+
+    try:
+        # Keeping this to not break backward compatibility.
+        pyproject_filename = root / "pyproject.toml"
+    except TypeError:
+        _root, _ = root
+        pyproject_filename = _root / "pyproject.toml"
 
     if not pyproject_filename.is_file():
         return defaults

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyls-black
-version = 0.4.7
+version = 0.4.8
 author = Rupert Bedford
 author_email = rupert@rupertb.com
 description = Black plugin for the Python Language Server


### PR DESCRIPTION
Make changes to support black 22.1.0, which changed the return type
of 'find_project_root' to a tuple.

Resolves: #40